### PR TITLE
Adding migration support for Postgresql

### DIFF
--- a/migrations/m150127_165542_update_rating_table.php
+++ b/migrations/m150127_165542_update_rating_table.php
@@ -17,7 +17,7 @@ class m150127_165542_update_rating_table extends Migration
         if ($this->db->driverName !== 'sqlite') {
             if ($this->db->driverName === 'pgsql') {
                 $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "date" DROP DEFAULT');
-                $this->alterColumn($this->tableName, 'date', Schema::TYPE_INTEGER . ' USING (id::integer)');
+                $this->alterColumn($this->tableName, 'date', Schema::TYPE_INTEGER . ' USING (date::integer)');
                 $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "date" SET NOT NULL');
 
                 $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "user_id" DROP NOT NULL');

--- a/migrations/m150127_165542_update_rating_table.php
+++ b/migrations/m150127_165542_update_rating_table.php
@@ -15,10 +15,22 @@ class m150127_165542_update_rating_table extends Migration
     public function up()
     {
         if ($this->db->driverName !== 'sqlite') {
-            $this->alterColumn($this->tableName, 'date', Schema::TYPE_INTEGER. ' NOT NULL');
-            $this->alterColumn($this->tableName, 'user_id', Schema::TYPE_INTEGER . ' NULL DEFAULT NULL');
+            if ($this->db->driverName === 'pgsql') {
+                $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "date" DROP DEFAULT');
+                $this->alterColumn($this->tableName, 'date', Schema::TYPE_INTEGER . ' USING (id::integer)');
+                $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "date" SET NOT NULL');
+
+                $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "user_id" DROP NOT NULL');
+                $this->alterColumn($this->tableName, 'user_id', Schema::TYPE_INTEGER . ' USING (user_id::integer)');
+                $this->execute('ALTER TABLE ' . $this->tableName . ' ALTER COLUMN "user_id" SET DEFAULT NULL');
+            } else {
+                $this->alterColumn($this->tableName, 'date', Schema::TYPE_INTEGER. ' NOT NULL');
+                $this->alterColumn($this->tableName, 'user_id', Schema::TYPE_INTEGER . ' NULL DEFAULT NULL');
+            }
         }
-        if ($this->db->driverName === 'mysql') {
+        if ($this->db->driverName === 'pgsql') {
+            $this->addColumn($this->tableName, 'user_ip', Schema::TYPE_STRING . '( 39 ) NOT NULL DEFAULT \'127.0.0.1\'');
+        } else if ($this->db->driverName === 'mysql') {
             $this->addColumn($this->tableName, 'user_ip', ' VARBINARY( 39 ) NOT NULL AFTER `user_id`');
         } else {
             $this->addColumn($this->tableName, 'user_ip', Schema::TYPE_STRING . '( 39 ) NOT NULL DEFAULT `127.0.0.1`');

--- a/migrations/m160126_140022_create_aggregate_rating_table.php
+++ b/migrations/m160126_140022_create_aggregate_rating_table.php
@@ -18,6 +18,11 @@ class m160126_140022_create_aggregate_rating_table extends Migration
         if ($this->db->driverName === 'mysql') {
             $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE=InnoDB';
         }
+        if ($this->db->driverName === 'pgsql') {
+            $ratingOptions = '(3,2) NOT NULL';
+        } else {
+            $ratingOptions = '(3,2) unsigned NOT NULL';
+        }
 
         $this->createTable($this->tableName, [
             'id' => Schema::TYPE_PK,
@@ -25,7 +30,7 @@ class m160126_140022_create_aggregate_rating_table extends Migration
             'target_id' => Schema::TYPE_INTEGER . ' NOT NULL',
             'likes' => Schema::TYPE_INTEGER . ' NOT NULL',
             'dislikes' => Schema::TYPE_INTEGER . ' NOT NULL',
-            'rating' => Schema::TYPE_FLOAT . '(3,2) unsigned NOT NULL'
+            'rating' => Schema::TYPE_FLOAT . $ratingOptions
         ], $tableOptions);
     }
 


### PR DESCRIPTION
I was trying your component in postgres, in order to alter columns you have to do it in separated commands and Yii2 doesn't offer support for this (it will be in 2.1) so I detect if it's postgres and do the right commands.

Also, there are no unsigned fields in postgres, that's why I had to remove it in the DB creation.